### PR TITLE
update for Gnome 40

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,6 +12,7 @@ const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 
 const Config = imports.misc.config;
+const SHELL_MAJOR = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 const SHELL_MINOR = parseInt(Config.PACKAGE_VERSION.split('.')[1]);
 
 let SSHQuickConnect = class SSHQuickConnect extends PanelMenu.Button {
@@ -71,7 +72,7 @@ let SSHQuickConnect = class SSHQuickConnect extends PanelMenu.Button {
  */
 
 // Compatibility with gnome-shell >= 3.32
-if (SHELL_MINOR > 30) {
+if (SHELL_MAJOR > 39 || SHELL_MINOR > 30) {
   SSHQuickConnect = GObject.registerClass(
     { GTypeName: 'SSHQuickConnect' },
     SSHQuickConnect

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "description": "This extension puts an icon in the panel with a simple dropdown menu that launches items from your ~.ssh/config",
   "version": 1,
   "shell-version": [
-    "3.36"
+    "3.36",
+    "40.0"
   ],
   "url": "https://www.github.com/ibrokemycomputer/gnome-shell-extension-ssh-quick-connect"
 }


### PR DESCRIPTION
I just installed Fedora 34 Beta which includes Gnome 40. This pull request allows the extension to work.