### PR TITLE
Added exception for non-existent debian_version file

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -167,7 +167,11 @@ let SSHQuickConnect = class SSHQuickConnect extends PanelMenu.Button {
    */
   getTerminalCommand() {
     const file = Gio.File.new_for_path('/etc/debian_version');
-    const isDebian = file.query_info('standard::*', 0, null)?.get_size() > 0;
+    try {
+      const isDebian = file.query_info('standard::*', 0, null)?.get_size() > 0;
+    } catch(e) {
+      const isDebian = 0
+    }
     const DESKTOP_SESSION = GLib.getenv('DESKTOP_SESSION');
     const SSH_COMMAND = ' -e ssh';
     let LINUX_TERMINAL = 'xterm';


### PR DESCRIPTION
In getTerminalCommand() executing file.query_info returns an error if the file does not exist (as per https://gjs-docs.gnome.org/gio20~2.66p/gio.file#method-query_info). 

If the extension is used on a non debain based system it will not work. Adding the try/catch solves this issue. 